### PR TITLE
Edit show.html.erb

### DIFF
--- a/app/views/submission_similarities/show.html.erb
+++ b/app/views/submission_similarities/show.html.erb
@@ -30,7 +30,7 @@
     </div>
   </div>
   <div class="table-container mt-3">
-    <table id="matchingStatementsTable" class="lines">
+    <table id="matchingStatementsTable" class="lines collapse show">
       <thead>
         <tr>
           <th class="lines_col">Submission by <%= @student1.id_string %></th>


### PR DESCRIPTION
Edit show.html.erb: initialize table class as "lines collapse show" instead of "lines"

Original class definition causes the first press of the button to change class to "lines collapse show", resulting in unreactive visuals.

Changing the class to "lines collapse show" instead allows the first press of the button to change the class to "lines collapse", which is reactive.

Helps to resolve issue #149 partially

Before:
![before](https://user-images.githubusercontent.com/24633766/172563842-cf8d449d-c0de-437b-8966-c4669b4b0124.gif)

After:
![after](https://user-images.githubusercontent.com/24633766/172563890-15e96feb-1bc8-4de2-aca8-bd238347da14.gif)

